### PR TITLE
Include old config id in ACS url (#core/25636)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 sourceCompatibility = '1.8'
-version = '22.03'
+version = '24.02.29'
 
 repositories {
     maven { url "https://repo.dotcms.com/artifactory/libs-release" }
@@ -14,7 +14,7 @@ configurations {
 dependencies {
 
     compile  ('io.vavr:vavr:0.9.3')
-    compile  ('com.dotcms:dotcms:21.01') { transitive = false }
+    compile  ('com.dotcms:dotcms:23.01.12') { transitive = false }
     compile  ('org.opensaml:opensaml-messaging-impl:3.3.1') { transitive = false }
     compile  ('commons-io:commons-io:2.8.0') { transitive = false }
     compile  ('org.apache.servicemix.bundles:org.apache.servicemix.bundles.opensaml:3.3.1_1'){

--- a/src/main/java/com/dotcms/saml/service/impl/EndpointServiceImpl.java
+++ b/src/main/java/com/dotcms/saml/service/impl/EndpointServiceImpl.java
@@ -5,6 +5,7 @@ import com.dotcms.saml.SamlConfigurationService;
 import com.dotcms.saml.SamlName;
 import com.dotcms.saml.service.internal.EndpointService;
 import com.dotcms.saml.service.external.SamlConstants;
+import com.dotmarketing.util.Config;
 import org.apache.commons.lang.StringUtils;
 
 /**
@@ -13,6 +14,9 @@ import org.apache.commons.lang.StringUtils;
  * @author jsanca
  */
 public class EndpointServiceImpl implements EndpointService {
+
+	private static final String DOTCMS_SAML_USE_IDP_CONFIG_ID = "dotcms.saml.use.idp.config.id";
+	private static final String IDP_CONFIG_IDENTIFIER = "idp.config.identifier";
 
 	private final SamlConfigurationService samlConfigurationService;
 
@@ -36,7 +40,7 @@ public class EndpointServiceImpl implements EndpointService {
 				+ spEndpointHostname(identityProviderConfiguration)
 				+ SamlConstants.ASSERTION_CONSUMER_ENDPOINT_DOTSAML3SP
 				+ "/"
-				+ identityProviderConfiguration.getId();
+				+ getIDPConfigId(identityProviderConfiguration);
 	}
 
 	/**
@@ -57,7 +61,7 @@ public class EndpointServiceImpl implements EndpointService {
 				+ spEndpointHostname(identityProviderConfiguration)
 				+ SamlConstants.LOGOUT_SERVICE_ENDPOINT_DOTSAML3SP
 				+ "/"
-				+ identityProviderConfiguration.getId();
+				+ getIDPConfigId(identityProviderConfiguration);
 	}
 
 	/**
@@ -124,4 +128,19 @@ public class EndpointServiceImpl implements EndpointService {
 		 
 		return spHostName;
 	}
+
+	/*
+	 * Utility to get the IDP config ID. If the config flag `dotcms.saml.use.idp.config.id`
+	 * is set, use the IDP config identifier set in the IDP property `idp.config.identifier`.
+	 * Otherwise, use the IDP config ID that is set to the host id.
+	 */
+	private String getIDPConfigId(final IdentityProviderConfiguration identityProviderConfiguration) {
+		if (Config.getBooleanProperty(DOTCMS_SAML_USE_IDP_CONFIG_ID, false)) {
+			if (identityProviderConfiguration.containsOptionalProperty(IDP_CONFIG_IDENTIFIER)) {
+				return (String) identityProviderConfiguration.getOptionalProperty(IDP_CONFIG_IDENTIFIER);
+			}
+		}
+		return identityProviderConfiguration.getId();
+	}
+
 }


### PR DESCRIPTION
Changed` getAssertionConsumerEndpoint()` and `getSingleLogoutEndpoint()` methods from `EndpointServiceImpl` class to return old configuration id instead of site id, when the flag to use the old configuration id is set (configuration property `dotcms.saml.use.idp.config.id`)