### PR TITLE
#31440 adding a fix to execute the saml logic before the logout

### DIFF
--- a/src/main/java/com/dotcms/saml/osgi/Activator.java
+++ b/src/main/java/com/dotcms/saml/osgi/Activator.java
@@ -96,7 +96,7 @@ public class Activator extends GenericBundleActivator {
         Try.run(()->delegate.remove(this.interceptorName, true))
                 .onFailure(e -> Logger.error(this.getClass().getName(), e.getMessage()));
 
-        delegate.add(samlWebInterceptor);
+        delegate.addFirst(samlWebInterceptor);
     }
 
 


### PR DESCRIPTION
Now the SAML logic will run before the dotCMS logout, so it ensures if SAML is turn on, will take precedence before the native behavior
 